### PR TITLE
added huq.io link to lists

### DIFF
--- a/blocklist.txt
+++ b/blocklist.txt
@@ -77936,6 +77936,7 @@
 ||huonvd.cn^
 ||huosuniao.com^
 ||hupsouft.net^
+||huq.io^
 ||hurapepy.com^
 ||hurdlewantingfalcon.com^
 ||hurdleyreer.info^

--- a/domains.txt
+++ b/domains.txt
@@ -77713,6 +77713,7 @@ hu.search.etargetnet.com
 hu.sharpmarketing.eu
 hu.static.etargetnet.com
 hu.xbhy.com
+huq.io
 huabil.com
 huaerdadi.com
 huaerduo.com


### PR DESCRIPTION
Added the main `huq.io` domain to three blocklists. Please see this article for details on the invasiveness of this data firm: https://archive.md/MQtYf (original/unarchived link: https://www.vice.com/en/article/5dgmqz/huq-location-data-opt-out-no-consent )

Thanks for the great blocklist.
~ Rooney